### PR TITLE
Remove use of Pairs

### DIFF
--- a/src/main/java/com/integerlimit/deprecatedapi/DeprecatedAPI.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/DeprecatedAPI.java
@@ -39,10 +39,12 @@ public class DeprecatedAPI {
         DeprecatedItems.addDeprecatedItem(Items.COOKED_BEEF).setTooltipMessage("Steak Sucks!");
         DeprecatedBlocks.addDeprecatedBlock(Blocks.DIRT).setTOPWailaMessage("Use Coarse Dirt instead!").setTooltipMessage("Dirt Sucks!");
         DeprecatedItems.addDeprecatedItem(Items.DIAMOND_SWORD);
-        DeprecatedBlocks.addDeprecatedBlock(Blocks.CONCRETE, 0).setMessages("Concrete is disabled for now.");
+        DeprecatedBlocks.addDeprecatedBlock(Blocks.CONCRETE).setMessages("Concrete is disabled for now.");
         DeprecatedBlocks.addDeprecatedBlock(Blocks.CONCRETE, 1).setMessages("This Concrete is disabled forever.");
         DeprecatedBlocks.addDeprecatedBlock(Blocks.STONE).setMessages("Dead");
         DeprecatedItems.addDeprecatedItem(Items.STONE_SWORD).setTooltipMessage("Worst");
+        DeprecatedItems.addDeprecatedItem(Items.COAL).setTooltipMessage("HOT!!!");
+        DeprecatedItems.addDeprecatedItem(Items.COAL, 1).setTooltipMessage("wood");
     }
 
     @Mod.EventHandler

--- a/src/main/java/com/integerlimit/deprecatedapi/DeprecatedAPI.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/DeprecatedAPI.java
@@ -39,7 +39,7 @@ public class DeprecatedAPI {
         DeprecatedItems.addDeprecatedItem(Items.COOKED_BEEF).setTooltipMessage("Steak Sucks!");
         DeprecatedBlocks.addDeprecatedBlock(Blocks.DIRT).setTOPWailaMessage("Use Coarse Dirt instead!").setTooltipMessage("Dirt Sucks!");
         DeprecatedItems.addDeprecatedItem(Items.DIAMOND_SWORD);
-        DeprecatedBlocks.addDeprecatedBlock(Blocks.CONCRETE).setMessages("Concrete is disabled for now.");
+        DeprecatedBlocks.addDeprecatedBlock(Blocks.CONCRETE, 0).setMessages("Concrete is disabled for now.");
         DeprecatedBlocks.addDeprecatedBlock(Blocks.CONCRETE, 1).setMessages("This Concrete is disabled forever.");
         DeprecatedBlocks.addDeprecatedBlock(Blocks.STONE).setMessages("Dead");
         DeprecatedItems.addDeprecatedItem(Items.STONE_SWORD).setTooltipMessage("Worst");

--- a/src/main/java/com/integerlimit/deprecatedapi/EventHandler.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/EventHandler.java
@@ -14,7 +14,7 @@ public class EventHandler {
     @SuppressWarnings("unused")
     public void tooltipEvent(ItemTooltipEvent event) {
         ItemStack itemStack = event.getItemStack();
-        DeprecatedItem item = DeprecatedItems.getItem(itemStack.getItem(), itemStack.getMetadata());
+        DeprecatedItem item = DeprecatedItems.getItem(itemStack);
         if (item != null) {
             event.getToolTip().add(TextFormatting.RED + item.getTooltipMessage());
         }

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlock.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlock.java
@@ -34,7 +34,7 @@ public class DeprecatedBlock extends DeprecatedItem{
     }
 
     public boolean matches(Block block, int meta) {
-        return this.meta == DeprecatedItems.WILDCARD_META ? Block.isEqualTo(block, this.block) : (Block.isEqualTo(block, this.block) && meta == this.meta);
+        return meta == DeprecatedItems.WILDCARD_META ? Block.isEqualTo(block, this.block) : (Block.isEqualTo(block, this.block) && meta == this.meta);
     }
 
     @Override

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlock.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlock.java
@@ -24,7 +24,7 @@ public class DeprecatedBlock extends DeprecatedItem{
 
     public DeprecatedBlock setBlock(Block block, int meta) {
         this.block = block;
-        this.setItem(new ItemStack(block, 1, meta));
+        this.setItem(new ItemStack(block, 1, meta), meta);
         return this;
     }
 
@@ -34,7 +34,7 @@ public class DeprecatedBlock extends DeprecatedItem{
     }
 
     public boolean matches(Block block, int meta) {
-        return this.stack.getItemDamage() == DeprecatedItems.WILDCARD_META ? Block.isEqualTo(block, this.block) : (Block.isEqualTo(block, this.block) && meta == stack.getItemDamage());
+        return this.meta == DeprecatedItems.WILDCARD_META ? Block.isEqualTo(block, this.block) : (Block.isEqualTo(block, this.block) && meta == this.meta);
     }
 
     @Override

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlock.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlock.java
@@ -1,10 +1,14 @@
 package com.integerlimit.deprecatedapi.api;
 
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+
 /**
  * A deprecated block. Has a TOP/WAILA tooltip + all tooltips in DeprecatedItem Object.
  */
 public class DeprecatedBlock extends DeprecatedItem{
     private String TOPWailaMessage;
+    protected Block block;
 
     @SuppressWarnings("unused")
     public DeprecatedBlock() {
@@ -18,9 +22,19 @@ public class DeprecatedBlock extends DeprecatedItem{
         return this;
     }
 
+    public DeprecatedBlock setBlock(Block block, int meta) {
+        this.block = block;
+        this.setItem(new ItemStack(block, 1, meta));
+        return this;
+    }
+
     @SuppressWarnings("unused")
     public String getTOPWailaMessage() {
         return TOPWailaMessage;
+    }
+
+    public boolean matches(Block block, int meta) {
+        return this.stack.getItemDamage() == DeprecatedItems.WILDCARD_META ? Block.isEqualTo(block, this.block) : (Block.isEqualTo(block, this.block) && meta == stack.getItemDamage());
     }
 
     @Override

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlocks.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlocks.java
@@ -11,10 +11,11 @@ import java.util.List;
 
 public class DeprecatedBlocks {
     private static final List<DeprecatedBlock> blocks = new ArrayList<>();
+    public static final int WILDCARD_META = -1;
 
     @SuppressWarnings({"unused", "UnusedReturnValue"})
     public static DeprecatedBlock addDeprecatedBlock(Block block) {
-        return addDeprecatedBlock(block, DeprecatedItems.WILDCARD_META);
+        return addDeprecatedBlock(block, WILDCARD_META);
     }
 
     @SuppressWarnings({"unused", "UnusedReturnValue"})
@@ -42,7 +43,10 @@ public class DeprecatedBlocks {
      */
     @Nullable
     public static DeprecatedBlock getBlock(Block block, int meta) {
-        return blocks.stream().filter((dep) -> dep.matches(block, meta)).findFirst().orElse(null);
+        DeprecatedBlock found = blocks.stream().filter((dep) -> dep.matches(block, meta)).findFirst().orElse(null);
+        if (found == null) found = blocks.stream().filter((dep) -> dep.matches(block, WILDCARD_META)).findFirst().orElse(null);
+
+        return found;
     }
 
     public static void logDeprecations() {
@@ -57,7 +61,7 @@ public class DeprecatedBlocks {
     }
 
     private static void sayDeprecated(ResourceLocation name, int meta) {
-        if (meta == DeprecatedItems.WILDCARD_META)
+        if (meta == WILDCARD_META)
             DeprecatedAPI.LOGGER.warn("Registry Name: {}, with any meta.", name);
 
         else

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlocks.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedBlocks.java
@@ -2,41 +2,37 @@ package com.integerlimit.deprecatedapi.api;
 
 
 import com.integerlimit.deprecatedapi.DeprecatedAPI;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.block.Block;
-import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DeprecatedBlocks {
-    private static final Map<Pair<Block, Integer>, DeprecatedBlock> blocks = new Object2ObjectOpenHashMap<>();
-    public static final int WILDCARD_META = -1;
+    private static final List<DeprecatedBlock> blocks = new ArrayList<>();
 
     @SuppressWarnings({"unused", "UnusedReturnValue"})
     public static DeprecatedBlock addDeprecatedBlock(Block block) {
-        return addDeprecatedBlock(block, WILDCARD_META);
+        return addDeprecatedBlock(block, DeprecatedItems.WILDCARD_META);
     }
 
     @SuppressWarnings({"unused", "UnusedReturnValue"})
     public static DeprecatedBlock addDeprecatedBlock(Block block, int meta) {
-        DeprecatedBlock deprecatedBlock = new DeprecatedBlock();
-        addDeprecatedBlock(Pair.of(block, meta), deprecatedBlock);
+        DeprecatedBlock deprecatedBlock = new DeprecatedBlock().setBlock(block, meta);
+        addDeprecatedBlock(deprecatedBlock);
         return deprecatedBlock;
     }
 
     @SuppressWarnings("unused")
-    public static void addDeprecatedBlock(Pair<Block, Integer> blockMetaPair, DeprecatedBlock block) {
+    public static void addDeprecatedBlock(DeprecatedBlock block) {
         if (DeprecatedAPI.pastPostInit()) {
-            DeprecatedAPI.LOGGER.fatal("Could not deprecate block " + blockMetaPair.getLeft().getRegistryName() + " as this must be done before postInit!");
+            DeprecatedAPI.LOGGER.fatal("Could not deprecate block " + block.block.getRegistryName() + " as this must be done before postInit!");
         }
 
-        DeprecatedItems.addDeprecatedItem(
-                Pair.of(Item.getItemFromBlock(blockMetaPair.getLeft()), blockMetaPair.getRight()), block);
-        blocks.put(blockMetaPair, block);
-        DeprecatedAPI.LOGGER.info("Block with resource location " + blockMetaPair.getLeft().getRegistryName() + " has been marked as deprecated.");
+        DeprecatedItems.addDeprecatedItem(block);
+        blocks.add(block);
+        DeprecatedAPI.LOGGER.info("Block with resource location " + block.block.getRegistryName() + " has been marked as deprecated.");
     }
 
     /**
@@ -46,14 +42,7 @@ public class DeprecatedBlocks {
      */
     @Nullable
     public static DeprecatedBlock getBlock(Block block, int meta) {
-        // Check proper meta first
-        DeprecatedBlock deprecatedBlock = blocks.get(Pair.of(block, meta));
-
-        // If not exist, use wild meta
-        if (deprecatedBlock == null)
-            deprecatedBlock = blocks.get(Pair.of(block, WILDCARD_META));
-
-        return deprecatedBlock;
+        return blocks.stream().filter((dep) -> dep.matches(block, meta)).findFirst().orElse(null);
     }
 
     public static void logDeprecations() {
@@ -62,14 +51,13 @@ public class DeprecatedBlocks {
 
         DeprecatedAPI.LOGGER.warn("DeprecatedAPI is installed. The following blocks are deprecated:");
 
-        blocks.forEach((key, value) -> sayDeprecated(key.getLeft().getRegistryName(), key.getRight())
-        );
+        blocks.forEach((dep) -> sayDeprecated(dep.block.getRegistryName(), dep.stack.getItemDamage()));
 
         DeprecatedAPI.LOGGER.warn("End Deprecated Blocks.");
     }
 
     private static void sayDeprecated(ResourceLocation name, int meta) {
-        if (meta == WILDCARD_META)
+        if (meta == DeprecatedItems.WILDCARD_META)
             DeprecatedAPI.LOGGER.warn("Registry Name: {}, with any meta.", name);
 
         else

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItem.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItem.java
@@ -1,11 +1,14 @@
 package com.integerlimit.deprecatedapi.api;
 
+import net.minecraft.item.ItemStack;
+
 /**
  * A deprecated item. Has a tooltip message.
  */
 public class DeprecatedItem {
     public static final String defaultMessage = "Deprecated";
     private String tooltipMessage;
+    protected ItemStack stack = ItemStack.EMPTY;
 
     @SuppressWarnings("unused")
     public DeprecatedItem() {
@@ -24,7 +27,16 @@ public class DeprecatedItem {
         return this;
     }
 
+    public DeprecatedItem setItem(ItemStack item) {
+        this.stack = item;
+        return this;
+    }
+
     public String getTooltipMessage() {
         return tooltipMessage;
+    }
+
+    public boolean matches(ItemStack item) {
+        return stack.getItemDamage() == DeprecatedItems.WILDCARD_META ? ItemStack.areItemsEqualIgnoreDurability(stack, item) : ItemStack.areItemStacksEqual(stack, item);
     }
 }

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItem.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItem.java
@@ -38,7 +38,7 @@ public class DeprecatedItem {
         return tooltipMessage;
     }
 
-    public boolean matches(ItemStack item) {
+    public boolean matches(ItemStack item, int meta) {
         return meta == DeprecatedItems.WILDCARD_META ? item.getItem() == stack.getItem() : ItemStack.areItemStacksEqual(stack, item);
     }
 }

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItem.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItem.java
@@ -9,6 +9,7 @@ public class DeprecatedItem {
     public static final String defaultMessage = "Deprecated";
     private String tooltipMessage;
     protected ItemStack stack = ItemStack.EMPTY;
+    protected int meta = 0;
 
     @SuppressWarnings("unused")
     public DeprecatedItem() {
@@ -27,8 +28,9 @@ public class DeprecatedItem {
         return this;
     }
 
-    public DeprecatedItem setItem(ItemStack item) {
+    public DeprecatedItem setItem(ItemStack item, int meta) {
         this.stack = item;
+        this.meta = meta;
         return this;
     }
 
@@ -37,6 +39,6 @@ public class DeprecatedItem {
     }
 
     public boolean matches(ItemStack item) {
-        return stack.getItemDamage() == DeprecatedItems.WILDCARD_META ? ItemStack.areItemsEqualIgnoreDurability(stack, item) : ItemStack.areItemStacksEqual(stack, item);
+        return meta == DeprecatedItems.WILDCARD_META ? item.getItem() == stack.getItem() : ItemStack.areItemStacksEqual(stack, item);
     }
 }

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItems.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItems.java
@@ -52,7 +52,10 @@ public class DeprecatedItems {
      */
     @Nullable
     public static DeprecatedItem getItem(ItemStack item) {
-        return items.stream().filter((dep) -> dep.matches(item)).findFirst().orElse(null);
+        DeprecatedItem found = items.stream().filter((dep) -> dep.matches(item, item.getItemDamage())).findFirst().orElse(null);
+        if (found == null) found = items.stream().filter((dep) -> dep.matches(item, -1)).findFirst().orElse(null);
+
+        return found;
     }
 
     public static void logDeprecations() {

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItems.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItems.java
@@ -20,13 +20,13 @@ public class DeprecatedItems {
 
     @SuppressWarnings({"unused", "UnusedReturnValue"})
     public static DeprecatedItem addDeprecatedItem(Item item, int meta) {
-        DeprecatedItem deprecatedItem = new DeprecatedItem().setItem(new ItemStack(item, 1, meta));
+        DeprecatedItem deprecatedItem = new DeprecatedItem().setItem(new ItemStack(item, 1, meta), meta);
         addDeprecatedItem(deprecatedItem);
         return deprecatedItem;
     }
 
     public static DeprecatedItem addDeprecatedItem(ItemStack item) {
-        DeprecatedItem deprecatedItem = new DeprecatedItem().setItem(item);
+        DeprecatedItem deprecatedItem = new DeprecatedItem().setItem(item, item.getItemDamage());
         addDeprecatedItem(deprecatedItem);
         return deprecatedItem;
     }

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItems.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItems.java
@@ -26,7 +26,7 @@ public class DeprecatedItems {
     }
 
     public static DeprecatedItem addDeprecatedItem(ItemStack item) {
-        DeprecatedItem deprecatedItem = new DeprecatedItem().setItem(item, item.getItemDamage());
+        DeprecatedItem deprecatedItem = new DeprecatedItem().setItem(item, item.getMetadata());
         addDeprecatedItem(deprecatedItem);
         return deprecatedItem;
     }
@@ -52,8 +52,8 @@ public class DeprecatedItems {
      */
     @Nullable
     public static DeprecatedItem getItem(ItemStack item) {
-        DeprecatedItem found = items.stream().filter((dep) -> dep.matches(item, item.getItemDamage())).findFirst().orElse(null);
-        if (found == null) found = items.stream().filter((dep) -> dep.matches(item, -1)).findFirst().orElse(null);
+        DeprecatedItem found = items.stream().filter((dep) -> dep.matches(item, item.getMetadata())).findFirst().orElse(null);
+        if (found == null) found = items.stream().filter((dep) -> dep.matches(item, WILDCARD_META)).findFirst().orElse(null);
 
         return found;
     }
@@ -64,7 +64,7 @@ public class DeprecatedItems {
 
         DeprecatedAPI.LOGGER.warn("DeprecatedAPI is installed. The following items are deprecated:");
 
-        items.forEach((dep) -> sayDeprecated(dep.stack.getItem().getRegistryName(), dep.stack.getItemDamage()));
+        items.forEach((dep) -> sayDeprecated(dep.stack.getItem().getRegistryName(), dep.stack.getMetadata()));
 
         DeprecatedAPI.LOGGER.warn("End Deprecated Items.");
     }

--- a/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItems.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/api/DeprecatedItems.java
@@ -1,16 +1,16 @@
 package com.integerlimit.deprecatedapi.api;
 
 import com.integerlimit.deprecatedapi.DeprecatedAPI;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DeprecatedItems {
-    private static final Map<Pair<Item, Integer>, DeprecatedItem> items = new Object2ObjectOpenHashMap<>();
+    private static final List<DeprecatedItem> items = new ArrayList<>();
     public static final int WILDCARD_META = -1;
 
     @SuppressWarnings({"unused", "UnusedReturnValue"})
@@ -20,37 +20,39 @@ public class DeprecatedItems {
 
     @SuppressWarnings({"unused", "UnusedReturnValue"})
     public static DeprecatedItem addDeprecatedItem(Item item, int meta) {
-        DeprecatedItem deprecatedItem = new DeprecatedItem();
-        addDeprecatedItem(Pair.of(item, meta), deprecatedItem);
+        DeprecatedItem deprecatedItem = new DeprecatedItem().setItem(new ItemStack(item, 1, meta));
+        addDeprecatedItem(deprecatedItem);
+        return deprecatedItem;
+    }
+
+    public static DeprecatedItem addDeprecatedItem(ItemStack item) {
+        DeprecatedItem deprecatedItem = new DeprecatedItem().setItem(item);
+        addDeprecatedItem(deprecatedItem);
         return deprecatedItem;
     }
 
     @SuppressWarnings("unused")
-    public static void addDeprecatedItem(Pair<Item, Integer> itemMetaPair, DeprecatedItem item) {
+    public static void addDeprecatedItem(DeprecatedItem item) {
+        if (item.stack.isEmpty()) {
+            DeprecatedAPI.LOGGER.fatal("Could not deprecate item as you can't deprecate an empty item.");
+            return;
+        }
         if (DeprecatedAPI.pastPostInit()) {
-            DeprecatedAPI.LOGGER.fatal("Could not deprecate item " + itemMetaPair.getLeft().getRegistryName() + " as this must be done before postInit!");
+            DeprecatedAPI.LOGGER.fatal("Could not deprecate item " + item.stack.getItem().getRegistryName() + " as this must be done before postInit!");
             return;
         }
 
-        items.put(itemMetaPair, item);
-        DeprecatedAPI.LOGGER.info("Item " + itemMetaPair.getLeft().getRegistryName() + " has been marked as deprecated.");
+        items.add(item);
+        DeprecatedAPI.LOGGER.info("Item " + item.stack.getItem().getRegistryName() + " has been marked as deprecated.");
     }
 
     /**
-     * @param item The Item.
-     * @param meta The Meta. Usually found from the ItemStack.
+     * @param item The Item
      * @return Null if not deprecated, otherwise, the DeprecatedItem Object.
      */
     @Nullable
-    public static DeprecatedItem getItem(Item item, int meta) {
-        // Check proper meta first
-        DeprecatedItem deprecatedItem = items.get(Pair.of(item, meta));
-
-        // If not exist, use wild meta
-        if (deprecatedItem == null)
-            deprecatedItem = items.get(Pair.of(item, WILDCARD_META));
-
-        return deprecatedItem;
+    public static DeprecatedItem getItem(ItemStack item) {
+        return items.stream().filter((dep) -> dep.matches(item)).findFirst().orElse(null);
     }
 
     public static void logDeprecations() {
@@ -59,8 +61,7 @@ public class DeprecatedItems {
 
         DeprecatedAPI.LOGGER.warn("DeprecatedAPI is installed. The following items are deprecated:");
 
-        items.forEach((key, value) -> sayDeprecated(key.getLeft().getRegistryName(), key.getRight())
-        );
+        items.forEach((dep) -> sayDeprecated(dep.stack.getItem().getRegistryName(), dep.stack.getItemDamage()));
 
         DeprecatedAPI.LOGGER.warn("End Deprecated Items.");
     }

--- a/src/main/java/com/integerlimit/deprecatedapi/mixin/ItemMixin.java
+++ b/src/main/java/com/integerlimit/deprecatedapi/mixin/ItemMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class ItemMixin {
     @Inject(method = "getForgeRarity", at = @At("HEAD"), cancellable = true, remap = false)
     private void setDeprecatedRarity(ItemStack stack, CallbackInfoReturnable<IRarity> cir) {
-        if (DeprecatedItems.getItem(stack.getItem(), stack.getMetadata()) != null) {
+        if (DeprecatedItems.getItem(stack) != null) {
             DeprecatedAPI.LOGGER.debug("Set Item " + stack.getItem().getRegistryName()
                     + ", with meta " + stack.getMetadata() + " to Deprecated Rarity.");
             cir.setReturnValue(DeprecatedRarity.DEPRECATED_RARITY);


### PR DESCRIPTION
Using `Pair`s for storing items in redundant and very inefficient.
This PR has the item/block and meta be stored in the `DeprecatedItem`/`DeprecatedBlock` class directly.